### PR TITLE
Find appropriate URL for given forge version

### DIFF
--- a/forge_install.py
+++ b/forge_install.py
@@ -1,19 +1,34 @@
 #!/usr/bin/env python3
-import sys
 import os
+import re
 import subprocess
+import sys
 import time
 from util import *
 
 # https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.12.2-14.23.5.2847/forge-1.12.2-14.23.5.2847-universal.jar
 
+def get_forge_url(mcver, mlver):
+    index_url = 'https://files.minecraftforge.net/net/minecraftforge/forge/index_%s.html' \
+            % mcver
+
+    outpath = '/tmp/forge-%s-index.html' % mcver
+    if not os.path.exists(outpath):
+        resp = download(index_url, outpath, False)
+        if resp != 200:
+            print("Got %d error trying to download index of Forge downloads" % resp)
+            sys.exit(2)
+
+    with open(outpath, 'r') as f:
+        url = re.search("href=(?:.*url=)?(.*%s.*\.jar)" % mlver, f.read()).group(1)
+
+    return url
 
 def main(manifest, mcver, mlver, packname, mc_dir, manual):
 
-    forge_fullver = mcver + '-' + mlver
-    url = 'https://files.minecraftforge.net/maven/net/minecraftforge/forge/%s/forge-%s-installer.jar' \
-            % (forge_fullver, forge_fullver)
-    outpath = '/tmp/forge-%s-installer.jar' % forge_fullver
+    url = get_forge_url(mcver, mlver)
+    outpath = '/tmp/%s' % url.split('/')[-1]
+
     if not os.path.exists(outpath):
         resp = download(url, outpath, True)
         if resp != 200:

--- a/forge_install.py
+++ b/forge_install.py
@@ -16,22 +16,28 @@ def get_forge_url(mcver, mlver):
     if not os.path.exists(outpath):
         resp = download(index_url, outpath, False)
         if resp != 200:
-            print("Got %d error trying to download index of Forge downloads" % resp)
-            sys.exit(2)
+            print("Got %d error trying to download Forge download index" % resp)
+            return ""
 
     with open(outpath, 'r') as f:
         match = re.search("href=(?:.*url=)?(.*%s.*\.jar)" % mlver, f.read())
         if match:
             url = match.group(1)
         else:
-            print("Could not find Forge version %s for Minecraft version %s" % (mlver, mcver))
-            sys.exit(2)
+            print("Could not find Forge download URL for version %s (Minecraft version %s)" % (mlver, mcver))
+            return ""
 
     return url
 
 def main(manifest, mcver, mlver, packname, mc_dir, manual):
 
     url = get_forge_url(mcver, mlver)
+
+    if not url:
+        print("Guessing Forge download URL")
+        forge_fullver = mcver + '-' + mlver
+        url = 'https://files.minecraftforge.net/maven/net/minecraftforge/forge/%s/forge-%s-installer.jar' % (forge_fullver, forge_fullver)
+
     outpath = '/tmp/%s' % url.split('/')[-1]
 
     if not os.path.exists(outpath):

--- a/forge_install.py
+++ b/forge_install.py
@@ -20,7 +20,12 @@ def get_forge_url(mcver, mlver):
             sys.exit(2)
 
     with open(outpath, 'r') as f:
-        url = re.search("href=(?:.*url=)?(.*%s.*\.jar)" % mlver, f.read()).group(1)
+        match = re.search("href=(?:.*url=)?(.*%s.*\.jar)" % mlver, f.read())
+        if match:
+            url = match.group(1)
+        else:
+            print("Could not find Forge version %s for Minecraft version %s" % (mlver, mcver))
+            sys.exit(2)
 
     return url
 


### PR DESCRIPTION
The URL for the Forge download is currently assumed to be in the form of `'.../forge/%s/forge-%s-installer.jar' % (forge_fullver, forge_fullver)`, but upon inspecting various versions, there is a greater variety. e.g
Minecraft 1.7.10, Forge 10.13.4.1614: `.../forge/1.7.10-10.13.4.1614-1.7.10/forge-1.7.10-10.13.4.1614-1.7.10-installer.jar`
Minecraft 1.7.10, Forge 10.13.3.1395: `.../forge/1.7.10-10.13.3.1395-1710ls/forge-1.7.10-10.13.3.1395-1710ls-installer.jar`
A function `get_forge_url()` was implemented to obtain the required download URL by scraping the Forge download page for the specified Minecraft version, and using a regex to find the appropriate URL for the specified Forge version.
The following shows its use:
```
Python 3.10.9 (main, Dec 25 2022, 21:29:15) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from forge_install import get_forge_url
>>> get_forge_url("1.7.10", "10.13.4.1614")
Downloading https://files.minecraftforge.net/net/minecraftforge/forge/index_1.7.10.html
'https://maven.minecraftforge.net/net/minecraftforge/forge/1.7.10-10.13.4.1614-1.7.10/forge-1.7.10-10.13.4.1614-1.7.10-installer.jar'
>>> get_forge_url("1.7.10", "10.13.3.1395")
'https://maven.minecraftforge.net/net/minecraftforge/forge/1.7.10-10.13.3.1395-1710ls/forge-1.7.10-10.13.3.1395-1710ls-installer.jar'
>>> get_forge_url("1.12.2", "14.23.5.2860")
Downloading https://files.minecraftforge.net/net/minecraftforge/forge/index_1.12.2.html
'https://maven.minecraftforge.net/net/minecraftforge/forge/1.12.2-14.23.5.2860/forge-1.12.2-14.23.5.2860-installer.jar'
```
This resolves the issue noted in #16.