### PR TITLE
Open manual downloads URLs automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ node_modules/
 .packs/
 global/
 packs/
-manual_downloads.txt
 
 # Modpack zip files
 *.zip

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ node_modules/
 .packs/
 global/
 packs/
+manual_downloads.txt
 
 # Modpack zip files
 *.zip

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ pip3 install --user requests
   * Note that deleting the modpack does not automatically delete any mod files, as
     they are stored in a central `.modcache` directory. To clean up unused mods, run
     the `clean.py` script.
+* You can use the `-b <browser-name>` flag in order to automatically open any modpacks
+  that need to be installed manually. Note that you need to replace `<browser-name>`
+  with the name of you browser you whish to use.
+* Use `python install.py -h` for a complete list of available commands
 
 ### How it Works
 The installer script goes through several steps to install the modpack:

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ pip3 install --user requests
   * Note that deleting the modpack does not automatically delete any mod files, as
     they are stored in a central `.modcache` directory. To clean up unused mods, run
     the `clean.py` script.
-* You can use the `-b <browser-name>` flag in order to automatically open any modpacks
-  that need to be installed manually. Note that you need to replace `<browser-name>`
-  with the name of you browser you whish to use.
+* You can use the `-b` flag in order to automatically open any modpacks
+  that need to be installed manually. This will open them in your default
+  browser using `webbrowser`.
 * Use `python install.py -h` for a complete list of available commands
 
 ### How it Works

--- a/install.py
+++ b/install.py
@@ -26,7 +26,7 @@ def start_launcher(mc_dir):
 def get_user_mcdir():
     return os.getenv('HOME') + '/.minecraft'
 
-def main(zipfile, user_mcdir=None, manual=False):
+def main(zipfile, user_mcdir=None, manual=False, open_browser=''):
     if user_mcdir is None:
         user_mcdir = get_user_mcdir()
 
@@ -164,9 +164,12 @@ def main(zipfile, user_mcdir=None, manual=False):
                         print("* %s (%s)" % (url, os.path.basename(outfile)))
 
                     with open("manual_downloads.txt", "w") as f:
-                        for url, _ in acutal_manual_dls:
+                        for url, _ in actual_manual_dls:
                             f.write(url + "\n")
-                    
+
+                    if open_browser != '':
+                        subprocess.run("{} $(cat manual_downloads.txt)".format(open_browser))
+
                     # TODO save user's configured downloads folder somewhere
                     user_downloads_dir = os.environ['HOME'] + '/Downloads'
                     print("Retrieving downloads from %s - if that isn't your browser's download location, enter" \
@@ -264,5 +267,9 @@ if __name__ == "__main__":
     parser.add_argument('zipfile')
     parser.add_argument('--manual', dest='forge_disable', action='store_true')
     parser.add_argument('--mcdir', dest='mcdir')
+    parser.add_argument(
+        '-b', '--open-browser', type=str, dest='open_browser', default='',
+        help='the browser to use to open the manual downloads'
+    )
     args = parser.parse_args(sys.argv[1:])
-    main(args.zipfile, args.mcdir, args.forge_disable)
+    main(args.zipfile, args.mcdir, args.forge_disable, args.open_browser)

--- a/install.py
+++ b/install.py
@@ -165,15 +165,9 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False):
                     for url, outfile in actual_manual_dls:
                         print("* %s (%s)" % (url, os.path.basename(outfile)))
 
-                    with open("manual_downloads.txt", "w") as f:
-                        for url, _ in actual_manual_dls:
-                            f.write(url + "\n")
-
                     if open_browser:
-                        urls = subprocess.checkout(["cat", "manual_downloads.txt"])
-
                         browser = webbrowser.get()
-                        for url in urls:
+                        for url in actual_manual_dls:
                             browser.open_new(url)
 
                     # TODO save user's configured downloads folder somewhere

--- a/install.py
+++ b/install.py
@@ -167,7 +167,7 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False):
 
                     if open_browser:
                         browser = webbrowser.get()
-                        for url in actual_manual_dls:
+                        for url, _ in actual_manual_dls:
                             browser.open_new(url)
 
                     # TODO save user's configured downloads folder somewhere

--- a/install.py
+++ b/install.py
@@ -6,9 +6,6 @@
 # will then generate a complete Minecraft install directory with all of the
 # mods and overrides installed.
 
-import forge_install
-import fabric_install
-import mod_download
 import os
 import sys
 import json
@@ -17,7 +14,12 @@ import time
 import random
 import shutil
 import argparse
+import webbrowser
 from distutils.dir_util import copy_tree
+
+import forge_install
+import fabric_install
+import mod_download
 from zipfile import ZipFile
 
 def start_launcher(mc_dir):
@@ -26,7 +28,7 @@ def start_launcher(mc_dir):
 def get_user_mcdir():
     return os.getenv('HOME') + '/.minecraft'
 
-def main(zipfile, user_mcdir=None, manual=False, open_browser=''):
+def main(zipfile, user_mcdir=None, manual=False, open_browser=False):
     if user_mcdir is None:
         user_mcdir = get_user_mcdir()
 
@@ -167,8 +169,12 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=''):
                         for url, _ in actual_manual_dls:
                             f.write(url + "\n")
 
-                    if open_browser != '':
-                        subprocess.run("{} $(cat manual_downloads.txt)".format(open_browser), shell=True)
+                    if open_browser:
+                        urls = subprocess.checkout(["cat", "manual_downloads.txt"])
+
+                        browser = webbrowser.get()
+                        for url in urls:
+                            browser.open_new(url)
 
                     # TODO save user's configured downloads folder somewhere
                     user_downloads_dir = os.environ['HOME'] + '/Downloads'
@@ -268,7 +274,7 @@ if __name__ == "__main__":
     parser.add_argument('--manual', dest='forge_disable', action='store_true')
     parser.add_argument('--mcdir', dest='mcdir')
     parser.add_argument(
-        '-b', '--open-browser', type=str, dest='open_browser', default='',
+        '-b', '--open-browser', action="store_true", dest='open_browser',
         help='the browser to use to open the manual downloads'
     )
     args = parser.parse_args(sys.argv[1:])

--- a/install.py
+++ b/install.py
@@ -162,6 +162,10 @@ def main(zipfile, user_mcdir=None, manual=False):
                     print("Please download them manually; the files will be retrieved from your downloads directly.")
                     for url, outfile in actual_manual_dls:
                         print("* %s (%s)" % (url, os.path.basename(outfile)))
+
+                    with open("manual_downloads.txt", "w") as f:
+                        for url, _ in acutal_manual_dls:
+                            f.write(url + "\n")
                     
                     # TODO save user's configured downloads folder somewhere
                     user_downloads_dir = os.environ['HOME'] + '/Downloads'

--- a/install.py
+++ b/install.py
@@ -168,7 +168,7 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=''):
                             f.write(url + "\n")
 
                     if open_browser != '':
-                        subprocess.run("{} $(cat manual_downloads.txt)".format(open_browser))
+                        subprocess.run("{} $(cat manual_downloads.txt)".format(open_browser), shell=True)
 
                     # TODO save user's configured downloads folder somewhere
                     user_downloads_dir = os.environ['HOME'] + '/Downloads'


### PR DESCRIPTION
It is rather annoying and slow to click on all the manual downloads. Instead the script could write the downloads a text file which can be open by a browser all at once.

With this PR, one can use

```
firefox-browser $(cat manual_downloads.txt)
```

which will open up all the URLs that were not able to download automatically. This works with any browser that can open URLs from terminal.