### PR TITLE
Add script to allow user to copy options files

### DIFF
--- a/copy_options.py
+++ b/copy_options.py
@@ -1,0 +1,64 @@
+import argparse
+
+
+parser = argparse.ArgumentParser(description="Copy options file from one pack to another.")
+parser.add_argument(
+    "copy_file",
+    action="store",
+    type=str,
+    help="The options file which should be copied.",
+)
+parser.add_argument(
+    "paste_file",
+    action="store",
+    type=str,
+    help="The options file which should be pasted.",
+)
+args = parser.parse_args()
+
+
+def get_data(file):
+    with open(file, "r") as f:
+        keys = []
+        values = []
+        for line in f.readlines():
+            key, value = line.rstrip().split(":")
+            keys.append(key)
+            values.append(value)
+        return keys, values
+
+
+def write_data(keys, values, file):
+    if len(keys) != len(values):
+        raise ValueError(
+            "The given keys and values don't match in length!", keys, values
+        )
+
+    with open(file, "w") as f:
+        f.writelines(["{}:{}\n".format(keys[i], values[i]) for i in range(len(keys))])
+
+
+def search_and_replace(file_to_copy, file_to_paste):
+    copy_keys, copy_values = get_data(file_to_copy)
+    paste_keys, paste_values = get_data(file_to_paste)
+
+    assert len(copy_values) == len(copy_values)
+    assert len(paste_keys) == len(paste_values)
+
+    for i, copy_key in enumerate(copy_keys):
+        for j, paste_key in enumerate(paste_keys):
+            if copy_key == paste_key:
+                paste_values[j] = copy_values[i]
+                break
+
+    return paste_keys, paste_values
+
+
+def main(file_to_copy, file_to_paste):
+    keys, values = search_and_replace(file_to_copy, file_to_paste)
+    print(keys, values)
+    write_data(keys, values, file_to_paste)
+
+
+if __name__ == "__main__":
+    main(args.copy_file, args.paste_file)


### PR DESCRIPTION
When upgrading modpacks it can be quite the hassle to copy the `options.txt`.
Mainly because often times there will be changes in the them,
making it impossible to simply copy paste them.

What `copy_options.py` does:

Copy all options that are present in `copy` to `paste`, those that are not present in both will be ignored (essentially it only copies the union of both sets). This is useful when for example upgrading modpacks to newer versions. Often times the options will change slightly, and it can be pretty annoying to replace them again. Simply copy pasting the whole file doesn't work because usually new options will appear or old ones will get deprecated.

This is not really needed to be inside of the modpack installer, however it's also not big enough to make it into it's own repo. I will personally use this a lot I feel like, so I wanted to share it, maybe you want to merge, maybe not.

Basic usage:

```
python copy_options.py path/to/copy_options_file.txt path/to/paste_options_file.txt
```

Might want to add some filters for certain keys like `resourcePacks`.
Usually one doesn't want to overwrite them.
