### PR TITLE
:sparkles: Progress bar, reformatting

### DIFF
--- a/clean.py
+++ b/clean.py
@@ -1,19 +1,23 @@
 import os
 import shutil
 
+
 def make_global(dir, gdir):
     if not os.path.exists(gdir):
         os.mkdir(gdir)
-    
+
     if not os.path.islink(dir):
         print("Converting %s to a global directory" % dir)
         if os.path.isdir(dir):
-            shutil.rmtree(dir) # safe for downloaded things, but not for user created content
+            shutil.rmtree(
+                dir
+            )  # safe for downloaded things, but not for user created content
         elif os.path.exists(dir):
             os.remove(dir)
         os.symlink(os.path.abspath(gdir), dir, True)
         return True
     return False
+
 
 def main():
     print("Modpack Maintenance v1.0.0")
@@ -23,21 +27,24 @@ def main():
     moved = 0
     deleted = 0
 
-    for packdirn in os.listdir('packs/'):
-        packdir = 'packs/' + packdirn
-        upd = make_global(packdir + '/.minecraft/assets', 'global/assets')
+    for packdirn in os.listdir("packs/"):
+        packdir = "packs/" + packdirn
+        upd = make_global(packdir + "/.minecraft/assets", "global/assets")
         moved += upd
-        for mod in os.listdir(packdir + '/.minecraft/mods'):
+        for mod in os.listdir(packdir + "/.minecraft/mods"):
             mods.add(mod)
 
-    for mod in os.listdir('.modcache'):
+    for mod in os.listdir(".modcache"):
         if mod not in mods:
             print("cleaning up %s" % mod)
-            deleted += os.stat('.modcache/' + mod).st_size
-            os.remove('.modcache/' + mod)
+            deleted += os.stat(".modcache/" + mod).st_size
+            os.remove(".modcache/" + mod)
 
-    print("Done! Deleted %.3f MiB of mods and migrated %d data folders" % \
-        (deleted / 1048576, moved))
+    print(
+        "Done! Deleted %.3f MiB of mods and migrated %d data folders"
+        % (deleted / 1048576, moved)
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/fabric_install.py
+++ b/fabric_install.py
@@ -6,9 +6,10 @@ import subprocess
 from util import *
 import xml.etree.ElementTree as et
 
+
 def get_latest_ver():
-    url = 'https://maven.fabricmc.net/net/fabricmc/fabric-installer/maven-metadata.xml'
-    outpath = '/tmp/fabric-versions.xml'
+    url = "https://maven.fabricmc.net/net/fabricmc/fabric-installer/maven-metadata.xml"
+    outpath = "/tmp/fabric-versions.xml"
     resp = download(url, outpath)
     if resp != 200:
         print("Error %d trying to download Fabric version list" % resp)
@@ -17,9 +18,10 @@ def get_latest_ver():
     xml_tree = et.parse(outpath)
     root = xml_tree.getroot()
 
-    ver_info = xml_tree.find('versioning')
-    release_ver = ver_info.find('release')
+    ver_info = xml_tree.find("versioning")
+    release_ver = ver_info.find("release")
     return release_ver.text
+
 
 def main(manifest, mcver, mlver, packname, mc_dir, manual):
     print("Installing Fabric modloader")
@@ -29,30 +31,44 @@ def main(manifest, mcver, mlver, packname, mc_dir, manual):
         print("Failed to acquire Fabric installer version")
         sys.exit(2)
 
-    url = 'https://maven.fabricmc.net/net/fabricmc/fabric-installer/%s/fabric-installer-%s.jar' \
+    url = (
+        "https://maven.fabricmc.net/net/fabricmc/fabric-installer/%s/fabric-installer-%s.jar"
         % (installer_ver, installer_ver)
-    outpath = '/tmp/fabric-%s-installer.jar' % installer_ver
+    )
+    outpath = "/tmp/fabric-%s-installer.jar" % installer_ver
     if not os.path.exists(outpath):
         resp = download(url, outpath)
         if resp != 200:
             print("Got error %d trying to download Fabric" % resp)
             sys.exit(2)
 
-    args = ['java', '-jar', outpath, 'client', '-snapshot', '-dir', mc_dir,
-            '-loader', mlver, '-mcversion', mcver]
+    args = [
+        "java",
+        "-jar",
+        outpath,
+        "client",
+        "-snapshot",
+        "-dir",
+        mc_dir,
+        "-loader",
+        mlver,
+        "-mcversion",
+        mcver,
+    ]
 
     if manual:
         # I guess they want manual mode for some reason
         print("Using the manual installer!")
         print("***** NEW: INSTALL TO THE MAIN .MINECRAFT DIRECTORY *****")
         print("*****   (Just hit 'OK' with the default settings)   *****")
-        subprocess.run(['java', '-jar', outpath])
+        subprocess.run(["java", "-jar", outpath])
     else:
         subprocess.run(args)
 
-    if not os.path.exists(mc_dir + '/versions/' + get_version_id(mcver, mlver)):
+    if not os.path.exists(mc_dir + "/versions/" + get_version_id(mcver, mlver)):
         print("Forge installation failed.")
         sys.exit(3)
 
+
 def get_version_id(mcver, mlver):
-    return 'fabric-loader-%s-%s' % (mlver, mcver)
+    return "fabric-loader-%s-%s" % (mlver, mcver)

--- a/forge_install.py
+++ b/forge_install.py
@@ -8,37 +8,46 @@ from util import *
 
 # https://files.minecraftforge.net/maven/net/minecraftforge/forge/1.12.2-14.23.5.2847/forge-1.12.2-14.23.5.2847-universal.jar
 
-def get_forge_url(mcver, mlver):
-    index_url = 'https://files.minecraftforge.net/net/minecraftforge/forge/index_%s.html' \
-            % mcver
 
-    outpath = '/tmp/forge-%s-index.html' % mcver
+def get_forge_url(mcver, mlver):
+    index_url = (
+        "https://files.minecraftforge.net/net/minecraftforge/forge/index_%s.html"
+        % mcver
+    )
+
+    outpath = "/tmp/forge-%s-index.html" % mcver
     if not os.path.exists(outpath):
         resp = download(index_url, outpath, False)
         if resp != 200:
             print("Got %d error trying to download Forge download index" % resp)
             return ""
 
-    with open(outpath, 'r') as f:
+    with open(outpath, "r") as f:
         match = re.search("href=(?:.*url=)?(.*%s.*\.jar)" % mlver, f.read())
         if match:
             url = match.group(1)
         else:
-            print("Could not find Forge download URL for version %s (Minecraft version %s)" % (mlver, mcver))
+            print(
+                "Could not find Forge download URL for version %s (Minecraft version %s)"
+                % (mlver, mcver)
+            )
             return ""
 
     return url
 
-def main(manifest, mcver, mlver, packname, mc_dir, manual):
 
+def main(manifest, mcver, mlver, packname, mc_dir, manual):
     url = get_forge_url(mcver, mlver)
 
     if not url:
         print("Guessing Forge download URL")
-        forge_fullver = mcver + '-' + mlver
-        url = 'https://files.minecraftforge.net/maven/net/minecraftforge/forge/%s/forge-%s-installer.jar' % (forge_fullver, forge_fullver)
+        forge_fullver = mcver + "-" + mlver
+        url = (
+            "https://files.minecraftforge.net/maven/net/minecraftforge/forge/%s/forge-%s-installer.jar"
+            % (forge_fullver, forge_fullver)
+        )
 
-    outpath = '/tmp/%s' % url.split('/')[-1]
+    outpath = "/tmp/%s" % url.split("/")[-1]
 
     if not os.path.exists(outpath):
         resp = download(url, outpath, True)
@@ -55,52 +64,56 @@ def main(manifest, mcver, mlver, packname, mc_dir, manual):
             print("^ ", end="", flush=True)
             time.sleep(0.05)
 
-        subprocess.run(['java', '-jar', outpath])
+        subprocess.run(["java", "-jar", outpath])
     else:
         compile_hack = False
-        if not os.path.exists('ForgeHack.class'):
+        if not os.path.exists("ForgeHack.class"):
             compile_hack = True
         else:
-            src_modtime = os.stat('ForgeHack.java').st_mtime
-            cls_modtime = os.stat('ForgeHack.class').st_mtime
+            src_modtime = os.stat("ForgeHack.java").st_mtime
+            cls_modtime = os.stat("ForgeHack.class").st_mtime
             if src_modtime > cls_modtime:
                 print("hack source file updated, recompiling")
                 compile_hack = True
 
         if compile_hack:
-            subprocess.run(['javac', 'ForgeHack.java'])
-        exit_code = subprocess.run(['java', 'ForgeHack', outpath, mc_dir]).returncode
+            subprocess.run(["javac", "ForgeHack.java"])
+        exit_code = subprocess.run(["java", "ForgeHack", outpath, mc_dir]).returncode
         if exit_code != 0:
             print("Error running the auto-installer, try using --manual.")
             sys.exit(3)
 
     ver_id = get_version_id(mcver, mlver)
-    if not os.path.exists(mc_dir + '/versions/' + ver_id):
+    if not os.path.exists(mc_dir + "/versions/" + ver_id):
         print("Forge installation not found.")
         if manual:
             print("Make sure you browsed to the correct minecraft directory.")
-        print("Expected to find a directory named %s in %s" % (ver_id, mc_dir + '/versions'))
-        print("If a similarly named directory was created in the expected folder, please submit a")
+        print(
+            "Expected to find a directory named %s in %s"
+            % (ver_id, mc_dir + "/versions")
+        )
+        print(
+            "If a similarly named directory was created in the expected folder, please submit a"
+        )
         print("bug report.")
         sys.exit(3)
 
 
 def get_version_id(mcver, mlver):
-    mcv_split = mcver.split('.')
+    mcv_split = mcver.split(".")
     mcv = int(mcv_split[0]) * 1000 + int(mcv_split[1])
-    mlv_split = mlver.split('.')
-    mlv = int(mlv_split[-1]) # modloader patch version
+    mlv_split = mlver.split(".")
+    mlv = int(mlv_split[-1])  # modloader patch version
 
     if mcv < 1008:
         # 1.7 (and possibly lower, haven't checked)
-        return '%s-Forge%s-%s' % (mcver, mlver, mcver)
+        return "%s-Forge%s-%s" % (mcver, mlver, mcver)
     elif mcv < 1010:
         # 1.8, 1.9
-        return '%s-forge%s-%s-%s' % (mcver, mcver, mlver, mcver)
+        return "%s-forge%s-%s-%s" % (mcver, mcver, mlver, mcver)
     elif mcv < 1012 or (mcv == 1012 and mlv < 2851):
         # 1.10, 1.11, 1.12 (up to 1.12.2-14.23.5.2847)
-        return '%s-forge%s-%s' % (mcver, mcver, mlver)
+        return "%s-forge%s-%s" % (mcver, mcver, mlver)
     else:
         # 1.12.2-14.23.5.2851 and above
-        return '%s-forge-%s' % (mcver, mlver)
-        
+        return "%s-forge-%s" % (mcver, mlver)

--- a/install.py
+++ b/install.py
@@ -16,6 +16,7 @@ import shutil
 import argparse
 import webbrowser
 import pathlib
+import tqdm
 
 import forge_install
 import fabric_install
@@ -27,27 +28,33 @@ from util import get_user_preference, set_user_preference
 # fall back to distutils copy_tree (the old solution) if needed
 if sys.version_info.minor >= 8:
     import shutil
+
     def copy_tree(src, dest):
         shutil.copytree(src, dest, dirs_exist_ok=True)
+
 else:
     from distutils import copy_tree
 
+
 def start_launcher(mc_dir):
-    subprocess.run(['minecraft-launcher', '--workDir', os.path.abspath(mc_dir)])
+    subprocess.run(["minecraft-launcher", "--workDir", os.path.abspath(mc_dir)])
+
 
 def get_user_mcdir():
     # get the possibles minecraft home folder
     possible_homes = (
-        os.getenv('HOME') + '/.minecraft',
-        os.getenv('HOME') + '/.var/app/com.mojang.Minecraft/.minecraft/'
+        os.getenv("HOME") + "/.minecraft",
+        os.getenv("HOME") + "/.var/app/com.mojang.Minecraft/.minecraft/",
     )
 
-    #remove unexistant paths
+    # remove unexistant paths
     possible_homes = [h for h in possible_homes if os.path.exists(h)]
 
     # no minecraft path found, ask the user to insert it
     if len(possible_homes) == 0:
-        return input("No minecraft installation detected, please instert the .minecraft folder path (ctrl + c to cancel): ")
+        return input(
+            "No minecraft installation detected, please instert the .minecraft folder path (ctrl + c to cancel): "
+        )
 
     # only one possible home has been found, just return it
     elif len(possible_homes) == 1:
@@ -58,40 +65,49 @@ def get_user_mcdir():
         while True:
             print("Multiple minecraft installations detected:")
             # print each folder with a number
-            i = 1 # to have more natural numbers, we're starting to 1
+            i = 1  # to have more natural numbers, we're starting to 1
             for home in possible_homes:
                 print(i, "- ", home)
                 i += 1
 
-            #ask the user which one to use
+            # ask the user which one to use
             home = input("Which minecraft folder should be used: ")
-            
+
             # if the user replied with something else than a number print an error and loop back
             if not home.isdigit():
                 print("Error: the response should be a number!")
-            
+
             # if the option doesn't exists, tell the user
-            elif int(home)-1 > len(possible_homes):
+            elif int(home) - 1 > len(possible_homes):
                 print("Error: this option doesn't exists!")
-            
+
             # everything seems to be ok, returning the associated path
             else:
-                return possible_homes[int(home)-1]
+                return possible_homes[int(home) - 1]
+
 
 # try to create a directory and all of its parent directories if they do not exist (like mkdir -p)
 def mkdirp(path):
     if type(path) != pathlib.Path:
-        path = pathlib.Path(path) # convert to pathlib path if a string is provided
+        path = pathlib.Path(path)  # convert to pathlib path if a string is provided
     try:
         path.mkdir(parents=True, exist_ok=True)
-    except TypeError: # exist_ok not defined
+    except TypeError:  # exist_ok not defined
         try:
             path.mkdir(parents=True)
         except FileExistsError:
             if not path.is_dir():
-                raise # keep exception if a non-directory file exists here
+                raise  # keep exception if a non-directory file exists here
 
-def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=False, sandbox=None):
+
+def main(
+    zipfile,
+    user_mcdir=None,
+    manual=False,
+    open_browser=False,
+    automated=False,
+    sandbox=None,
+):
     # check which minecraft folder to use
     if user_mcdir is None:
         # load the user preferences file
@@ -104,9 +120,14 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
     # check if the user wants to save the path as default if it's different from the one in the preferences
     pref_mcdir = get_user_preference("minecraft_dir")
     if user_mcdir != pref_mcdir and not automated:
-        #ask the user if he wants to save the path as default
-        print("Changes detected in the minecraft folder path. \n OLD: %s\n NEW: %s" % (pref_mcdir, user_mcdir))
-        update_preferences = input("would you like to save this new path as default? (Y/n) ")
+        # ask the user if he wants to save the path as default
+        print(
+            "Changes detected in the minecraft folder path. \n OLD: %s\n NEW: %s"
+            % (pref_mcdir, user_mcdir)
+        )
+        update_preferences = input(
+            "would you like to save this new path as default? (Y/n) "
+        )
 
         # if the user wants to save the path as default, save it
         if update_preferences.lower().startswith("y") or update_preferences == "":
@@ -116,49 +137,57 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
             print("Okay, no updates were made.")
 
     # check if the minecraft dir should be moved into a sandbox
-    sandbox_root = str(pathlib.Path(user_mcdir).parent) + '/modpack'
+    sandbox_root = str(pathlib.Path(user_mcdir).parent) + "/modpack"
     sandbox_pref = get_user_preference("sandbox")
     should_sandbox = sandbox_pref
     # if the preference was not set, check it
     # - also check if the mcdir has changed
     if should_sandbox is None or user_mcdir != pref_mcdir:
-        should_sandbox = ".var/app" in user_mcdir # flatpak paths look like this
+        should_sandbox = ".var/app" in user_mcdir  # flatpak paths look like this
     if sandbox is None:
         sandbox = should_sandbox
         # if this is new
         if sandbox and not sandbox_pref and not automated:
             # check if the user is ok with applying sandbox mode
-            print("This minecraft directory seems to be installed from Flatpak. Since Flatpak apps")
-            print("can't access the filesystem, 'sandbox mode' has been enabled, which will place ")
-            print("modpacks alongside the main '.minecraft' installation so that they exist where ")
+            print(
+                "This minecraft directory seems to be installed from Flatpak. Since Flatpak apps"
+            )
+            print(
+                "can't access the filesystem, 'sandbox mode' has been enabled, which will place "
+            )
+            print(
+                "modpacks alongside the main '.minecraft' installation so that they exist where "
+            )
             print("the app can access them.")
             sandbox_ok = input("Is this OK? [Y/n]")
-            if sandbox_ok.lower()[:1] not in ['y', '']:
+            if sandbox_ok.lower()[:1] not in ["y", ""]:
                 sandbox = False
     if sandbox != sandbox_pref:
         # update preference
         if sandbox:
-            print("Enabling sandboxing - this can be changed with --no-sandbox if it breaks things")
+            print(
+                "Enabling sandboxing - this can be changed with --no-sandbox if it breaks things"
+            )
             print("* Modpack data will be stored at %s" % sandbox_root)
         set_user_preference("sandbox", sandbox)
 
-    install_root = sandbox_root if sandbox else '.'
+    install_root = sandbox_root if sandbox else "."
     mkdirp(install_root)
-    
+
     # Extract pack
     packname = os.path.splitext(zipfile)[0]
     packname = os.path.basename(packname)
-    packdata_dir = '.packs/' + packname
+    packdata_dir = ".packs/" + packname
     if os.path.isdir(packdata_dir):
         print("[pack data already unzipped]")
     else:
-        mkdirp('.packs/')
+        mkdirp(".packs/")
         print("Extracting %s" % zipfile)
-        with ZipFile(zipfile, 'r') as zf:
+        with ZipFile(zipfile, "r") as zf:
             zf.extractall(packdata_dir)
 
     # Generate minecraft environment
-    mc_dir = install_root + '/packs/' + packname + '/.minecraft'
+    mc_dir = install_root + "/packs/" + packname + "/.minecraft"
     if os.path.isdir(mc_dir):
         print("[minecraft dir already created]")
     else:
@@ -166,23 +195,31 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
         mkdirp(mc_dir)
 
         print("Creating symlinks")
-        global_dir = install_root + '/global'
-        mkdirp(global_dir + '/libraries')
-        mkdirp(global_dir + '/resourcepacks')
-        mkdirp(global_dir + '/saves')
-        mkdirp(global_dir + '/shaderpacks')
-        mkdirp(global_dir + '/assets')
+        global_dir = install_root + "/global"
+        mkdirp(global_dir + "/libraries")
+        mkdirp(global_dir + "/resourcepacks")
+        mkdirp(global_dir + "/saves")
+        mkdirp(global_dir + "/shaderpacks")
+        mkdirp(global_dir + "/assets")
 
-        os.symlink(os.path.abspath(global_dir + '/libraries'), mc_dir + '/libraries', True)
-        os.symlink(os.path.abspath(global_dir + '/resourcepacks'), mc_dir + '/resourcepacks', True)
-        os.symlink(os.path.abspath(global_dir + '/saves'), mc_dir + '/saves', True)
-        os.symlink(os.path.abspath(global_dir + '/shaderpacks'), mc_dir + '/shaderpacks', True)
-        os.symlink(os.path.abspath(global_dir + '/assets'), mc_dir + '/assets', True)
+        os.symlink(
+            os.path.abspath(global_dir + "/libraries"), mc_dir + "/libraries", True
+        )
+        os.symlink(
+            os.path.abspath(global_dir + "/resourcepacks"),
+            mc_dir + "/resourcepacks",
+            True,
+        )
+        os.symlink(os.path.abspath(global_dir + "/saves"), mc_dir + "/saves", True)
+        os.symlink(
+            os.path.abspath(global_dir + "/shaderpacks"), mc_dir + "/shaderpacks", True
+        )
+        os.symlink(os.path.abspath(global_dir + "/assets"), mc_dir + "/assets", True)
 
     # Install Forge
     print("Installing modloader")
     try:
-        with open(packdata_dir + '/manifest.json', 'r') as mf:
+        with open(packdata_dir + "/manifest.json", "r") as mf:
             manifest = json.load(mf)
     except (json.JsonDecodeError, OSError) as e:
         print("Manifest file not found or was corrupted.")
@@ -197,20 +234,21 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
     # * modpack name
     # * minecraft directory
     # * manual flag: run automatically or show GUI
-    modloaders = {
-        'forge': forge_install,
-        'fabric': fabric_install
-    }
+    modloaders = {"forge": forge_install, "fabric": fabric_install}
 
     # I have not yet seen a modpack that has multiple modloaders
-    if len(manifest['minecraft']['modLoaders']) != 1:
-        print("This modpack (%s) has %d modloaders, instead of the normal 1."
-                % (packname, len(manifest['minecraft']['modLoaders'])))
-        print("This is currently unsupported, so expect the installation to fail in some way.")
+    if len(manifest["minecraft"]["modLoaders"]) != 1:
+        print(
+            "This modpack (%s) has %d modloaders, instead of the normal 1."
+            % (packname, len(manifest["minecraft"]["modLoaders"]))
+        )
+        print(
+            "This is currently unsupported, so expect the installation to fail in some way."
+        )
         print("Please report which modpack caused this to the maintainer at:")
         print("  https://github.com/cdbbnnyCode/modpack-installer/issues")
-    modloader, mlver = manifest['minecraft']['modLoaders'][0]["id"].split('-')
-    mcver = manifest['minecraft']['version']
+    modloader, mlver = manifest["minecraft"]["modLoaders"][0]["id"].split("-")
+    mcver = manifest["minecraft"]["version"]
 
     if modloader not in modloaders:
         print("This modloader (%s) is not supported." % modloader)
@@ -220,50 +258,58 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
     print("Updating user launcher profiles")
 
     # user_mcdir = get_user_mcdir()
-    with open(user_mcdir + '/launcher_profiles.json', 'r') as f:
+    with open(user_mcdir + "/launcher_profiles.json", "r") as f:
         launcher_profiles = json.load(f)
 
     # add/overwrite the profile
     # TODO: add options for maximum memory
     # or config file for the java argument string
     ml_version_id = modloaders[modloader].get_version_id(mcver, mlver)
-    launcher_profiles['profiles'][packname] = {
+    launcher_profiles["profiles"][packname] = {
         "icon": "Chest",
         "javaArgs": "-Xmx4G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=50 -XX:G1HeapRegionSize=32M",
         "lastVersionId": ml_version_id,
-        "name": packname.replace('+', ' '),
+        "name": packname.replace("+", " "),
         "gameDir": os.path.abspath(mc_dir),
-        "type": "custom"
+        "type": "custom",
     }
-    
-    with open(user_mcdir + '/launcher_profiles.json', 'w') as f:
+
+    with open(user_mcdir + "/launcher_profiles.json", "w") as f:
         json.dump(launcher_profiles, f, indent=2)
 
-    if not os.path.exists(user_mcdir + '/versions/' + ml_version_id):
+    if not os.path.exists(user_mcdir + "/versions/" + ml_version_id):
         modloaders[modloader].main(manifest, mcver, mlver, packname, user_mcdir, manual)
     else:
         print("[modloader already installed]")
 
     # Download mods
-    if not os.path.exists(mc_dir + '/.mod_success'):
-        modcache_dir = install_root + '/.modcache'
-        mkdirp(mc_dir + '/mods')
+    if not os.path.exists(mc_dir + "/.mod_success"):
+        modcache_dir = install_root + "/.modcache"
+        mkdirp(mc_dir + "/mods")
         mkdirp(modcache_dir)
         print("Downloading mods")
 
-        mods, manual_downloads = mod_download.main(packdata_dir + '/manifest.json', modcache_dir)
+        mods, manual_downloads = mod_download.main(
+            packdata_dir + "/manifest.json", modcache_dir
+        )
         if len(manual_downloads) > 0:
             while True:
-                actual_manual_dls = [] # which ones aren't already downloaded
+                actual_manual_dls = []  # which ones aren't already downloaded
                 for url, resp in manual_downloads:
                     outfile = resp[3]
                     if not os.path.exists(outfile):
                         actual_manual_dls.append((url, outfile))
                 if len(actual_manual_dls) > 0:
                     print("====MANUAL DOWNLOAD REQUIRED====")
-                    print("The following mods cannot be downloaded due to the new Project Distribution Toggle.")
-                    print("Please download them manually; the files will be retrieved from your downloads directly.")
-                    print("If there is a 404 error opening any of these links, try replacing 'legacy.curseforge.com' with 'www.curseforge.com'")
+                    print(
+                        "The following mods cannot be downloaded due to the new Project Distribution Toggle."
+                    )
+                    print(
+                        "Please download them manually; the files will be retrieved from your downloads directly."
+                    )
+                    print(
+                        "If there is a 404 error opening any of these links, try replacing 'legacy.curseforge.com' with 'www.curseforge.com'"
+                    )
                     for url, outfile in actual_manual_dls:
                         print("* %s (%s)" % (url, os.path.basename(outfile)))
 
@@ -273,10 +319,14 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
                             browser.open_new(url)
 
                     # TODO save user's configured downloads folder somewhere
-                    user_downloads_dir = os.environ['HOME'] + '/Downloads'
-                    print("Retrieving downloads from %s - if that isn't your browser's download location, enter" \
-                            % user_downloads_dir)
-                    print("the correct location below. Otherwise, press Enter to continue.")
+                    user_downloads_dir = os.environ["HOME"] + "/Downloads"
+                    print(
+                        "Retrieving downloads from %s - if that isn't your browser's download location, enter"
+                        % user_downloads_dir
+                    )
+                    print(
+                        "the correct location below. Otherwise, press Enter to continue."
+                    )
                     req_downloads_dir = input()
 
                     req_downloads_dir = os.path.expanduser(req_downloads_dir)
@@ -286,10 +336,10 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
                         else:
                             user_downloads_dir = req_downloads_dir
                     print("Finding files in %s..." % user_downloads_dir)
-                    
+
                     for url, outfile in actual_manual_dls:
-                        fname = os.path.basename(outfile).replace(' ', '+')
-                        dl_path = user_downloads_dir + '/' + fname
+                        fname = os.path.basename(outfile).replace(" ", "+")
+                        dl_path = user_downloads_dir + "/" + fname
                         if os.path.exists(dl_path):
                             print(dl_path)
                             shutil.move(dl_path, outfile)
@@ -297,60 +347,64 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
                     break
 
         # Link mods
-        print("Linking mods")
-        if not os.path.isdir(mc_dir + '/resources'):
-            os.mkdir(mc_dir + '/resources')
+        if not os.path.isdir(mc_dir + "/resources"):
+            os.mkdir(mc_dir + "/resources")
 
         has_datapacks = False
 
-        for mod in mods:
+        for mod in tqdm.tqdm(mods, unit="mods", desc="Linking mods"):
             jar = mod[0]
             ftype = mod[1]
-            if ftype == 'mc-mods':
-                modfile = mc_dir + '/mods/' + os.path.basename(jar)
+            if ftype == "mc-mods":
+                modfile = mc_dir + "/mods/" + os.path.basename(jar)
                 if not os.path.exists(modfile):
                     os.symlink(os.path.abspath(jar), modfile)
-            elif ftype == 'texture-packs':
-                print("Extracting texture pack %s" % jar)
-                texpack_dir = '/tmp/%06d' % random.randint(0, 999999)
+            elif ftype == "texture-packs":
+                tqdm.tqdm.write("Extracting texture pack %s" % jar)
+                texpack_dir = "/tmp/%06d" % random.randint(0, 999999)
                 os.mkdir(texpack_dir)
-                with ZipFile(jar, 'r') as zf:
+                with ZipFile(jar, "r") as zf:
                     zf.extractall(texpack_dir)
-                if os.path.exists(texpack_dir + '/data'):
+                if os.path.exists(texpack_dir + "/data"):
                     # we have a data pack, don't extract it
                     has_datapacks = True
-                    print("-> is actually data pack, placing into datapacks")
-                    if not os.path.isdir(mc_dir + '/datapacks'):
-                        os.mkdir(mc_dir + '/datapacks')
-                    os.symlink(os.path.abspath(jar), mc_dir + '/datapacks/' + os.path.basename(jar))
+                    tqdm.tqdm.write("-> is actually data pack, placing into datapacks")
+                    if not os.path.isdir(mc_dir + "/datapacks"):
+                        os.mkdir(mc_dir + "/datapacks")
+                    os.symlink(
+                        os.path.abspath(jar),
+                        mc_dir + "/datapacks/" + os.path.basename(jar),
+                    )
                 else:
-                    for subdir in os.listdir(texpack_dir + '/assets'):
-                        f = texpack_dir + '/assets/' + subdir
+                    for subdir in os.listdir(texpack_dir + "/assets"):
+                        f = texpack_dir + "/assets/" + subdir
                         if os.path.isdir(f):
-                            copy_tree(f, mc_dir + '/resources/' + subdir)
+                            copy_tree(f, mc_dir + "/resources/" + subdir)
                         else:
-                            shutil.copyfile(f, mc_dir + '/resources/' + subdir)
+                            shutil.copyfile(f, mc_dir + "/resources/" + subdir)
                 shutil.rmtree(texpack_dir)
             else:
-                print("Unknown file type %s" % ftype)
+                tqdm.tqdm.write("Unknown file type %s" % ftype)
                 sys.exit(1)
 
-    else: # if mods already downloaded
+    else:  # if mods already downloaded
         # assume there might be datapacks if a datapacks directory exists
-        has_datapacks = os.path.isdir(mc_dir + '/datapacks')
+        has_datapacks = os.path.isdir(mc_dir + "/datapacks")
 
     # Create success marker (does nothing if it already existed)
-    with open(mc_dir + '/.mod_success', 'wb') as f:
+    with open(mc_dir + "/.mod_success", "wb") as f:
         pass
 
     # Copy overrides
-    print("Copying overrides")
-    for subdir in os.listdir(packdata_dir + '/overrides'):
-        print(subdir + "...")
-        if os.path.isdir(packdata_dir + '/overrides/' + subdir):
-            copy_tree(packdata_dir + '/overrides/' + subdir, mc_dir + '/' + subdir)
+    for subdir in tqdm.tqdm(
+        os.listdir(packdata_dir + "/overrides"), unit="files", desc="Copying overrides"
+    ):
+        if os.path.isdir(packdata_dir + "/overrides/" + subdir):
+            copy_tree(packdata_dir + "/overrides/" + subdir, mc_dir + "/" + subdir)
         else:
-            shutil.copyfile(packdata_dir + '/overrides/' + subdir, mc_dir + '/' + subdir)
+            shutil.copyfile(
+                packdata_dir + "/overrides/" + subdir, mc_dir + "/" + subdir
+            )
     print("Done!")
     print()
     print()
@@ -359,35 +413,56 @@ def main(zipfile, user_mcdir=None, manual=False, open_browser=False, automated=F
     print("The modpack will be available in your installations list.")
     if has_datapacks:
         print("!!!! THIS MODPACK CONTAINS DATA PACKS !!!!")
-        print("When creating a new world, please click the 'Data Packs' button and make sure the installed datapacks are present!")
-        print("* Data packs have been stored in: " + os.path.abspath(mc_dir + '/datapacks'))
-        print("* If there are no data packs shown, drag all of the zip files from this directory into your game window " \
-              + "and make sure they are enabled for the world.")
+        print(
+            "When creating a new world, please click the 'Data Packs' button and make sure the installed datapacks are present!"
+        )
+        print(
+            "* Data packs have been stored in: "
+            + os.path.abspath(mc_dir + "/datapacks")
+        )
+        print(
+            "* If there are no data packs shown, drag all of the zip files from this directory into your game window "
+            + "and make sure they are enabled for the world."
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('zipfile')
-    parser.add_argument('--manual', dest='forge_disable', action='store_true'),
+    parser.add_argument("zipfile")
+    parser.add_argument("--manual", dest="forge_disable", action="store_true"),
     parser.add_argument(
-        '--mcdir', dest='mcdir',
-        help="Minecraft directory, overrides stored preferences"
+        "--mcdir",
+        dest="mcdir",
+        help="Minecraft directory, overrides stored preferences",
     )
     parser.add_argument(
-        '--automated', dest='automated', action='store_true', 
-        help="Intended for use by other scripts, limit blocking prompts"
+        "--automated",
+        dest="automated",
+        action="store_true",
+        help="Intended for use by other scripts, limit blocking prompts",
     )
     parser.add_argument(
-        '-b', '--open-browser', action="store_true", dest='open_browser',
-        help='the browser to use to open the manual downloads'
+        "-b",
+        "--open-browser",
+        action="store_true",
+        dest="open_browser",
+        help="the browser to use to open the manual downloads",
     )
     parser.add_argument(
-        '-s', '--sandbox', action='store_true', dest='sandbox', default=None,
+        "-s",
+        "--sandbox",
+        action="store_true",
+        dest="sandbox",
+        default=None,
         help="Force 'sandbox' mode (for Flatpak etc.), places files alongside .minecraft dir so that they are"
-            +"accessible from inside a sandboxed environment"
+        + "accessible from inside a sandboxed environment",
     )
     parser.add_argument(
-        '--no-sandbox', action='store_false', dest='sandbox', default=None,
-        help="Force-disable 'sandbox' mode"
+        "--no-sandbox",
+        action="store_false",
+        dest="sandbox",
+        default=None,
+        help="Force-disable 'sandbox' mode",
     )
     args = parser.parse_args(sys.argv[1:])
     main(

--- a/migrate.py
+++ b/migrate.py
@@ -3,10 +3,11 @@ import json
 import shutil
 import sys
 
+
 def main():
-    user_mcdir = os.getenv('HOME') + '/.minecraft'
+    user_mcdir = os.getenv("HOME") + "/.minecraft"
     if len(sys.argv) > 1:
-        if sys.argv[1] == '-h' or sys.argv[1] == '--help':
+        if sys.argv[1] == "-h" or sys.argv[1] == "--help":
             print("Usage:")
             print("    %s -h|--help    Print this help message")
             print("    %s [mcdir]      Migrate modpack launcher data")
@@ -14,59 +15,70 @@ def main():
         else:
             user_mcdir = sys.argv[1]
 
-    with open(user_mcdir + '/launcher_profiles.json', 'r') as f:
+    with open(user_mcdir + "/launcher_profiles.json", "r") as f:
         launcher_profiles = json.load(f)
 
-    for packdirn in os.listdir('packs/'):
+    for packdirn in os.listdir("packs/"):
         print(packdirn)
-        pack_profiles_file = 'packs/' + packdirn + '/.minecraft/launcher_profiles.json'
+        pack_profiles_file = "packs/" + packdirn + "/.minecraft/launcher_profiles.json"
         if os.path.exists(pack_profiles_file):
-            with open(pack_profiles_file, 'r') as f:
+            with open(pack_profiles_file, "r") as f:
                 old_profiles = json.load(f)
-            
+
             found = False
-            for profname in old_profiles['profiles']:
-                profile = old_profiles['profiles'][profname]
-                if profile['type'] == 'custom' or profile['type'] == '':
+            for profname in old_profiles["profiles"]:
+                profile = old_profiles["profiles"][profname]
+                if profile["type"] == "custom" or profile["type"] == "":
                     found = True
                     # print(profile)
 
-                    version = profile['lastVersionId']
-                    launcher_profiles['profiles'][packdirn] = {
+                    version = profile["lastVersionId"]
+                    launcher_profiles["profiles"][packdirn] = {
                         "icon": "Chest",
                         "javaArgs": "-Xmx4G -XX:+UnlockExperimentalVMOptions -XX:+UseG1GC -XX:G1NewSizePercent=20 -XX:G1ReservePercent=20 -XX:MaxGCPauseMillis=50 -XX:G1HeapRegionSize=32M",
                         "lastVersionId": version,
-                        "name": packdirn.replace('+', ' '),
-                        "gameDir": os.path.abspath('packs/' + packdirn + '/.minecraft'),
-                        "type": "custom"
+                        "name": packdirn.replace("+", " "),
+                        "gameDir": os.path.abspath("packs/" + packdirn + "/.minecraft"),
+                        "type": "custom",
                     }
 
-                    launcher_dir = 'packs/' + packdirn + '/.minecraft/launcher'
+                    launcher_dir = "packs/" + packdirn + "/.minecraft/launcher"
                     print("add profile %s -- version %s" % (packdirn, version))
                     if os.path.exists(launcher_dir):
                         print("remove launcher directory")
                         shutil.rmtree(launcher_dir)
 
                     # copy the version json
-                    version_dir = user_mcdir + '/versions/' + version
+                    version_dir = user_mcdir + "/versions/" + version
                     if not os.path.exists(version_dir):
                         print("copying version info")
                         os.mkdir(version_dir)
-                        shutil.copy2('packs/' + packdirn + '/.minecraft/versions/' + version + '/' + version + '.json',
-                            version_dir)
+                        shutil.copy2(
+                            "packs/"
+                            + packdirn
+                            + "/.minecraft/versions/"
+                            + version
+                            + "/"
+                            + version
+                            + ".json",
+                            version_dir,
+                        )
 
             if not found:
-                print("failed to migrate modpack %s, no launcher profile found" % packdirn)
+                print(
+                    "failed to migrate modpack %s, no launcher profile found" % packdirn
+                )
 
     print("copying libraries")
-    if os.path.exists('global/libraries'):
-        shutil.copytree('global/libraries', user_mcdir + '/libraries', dirs_exist_ok=True)
-    
-    with open(user_mcdir + '/launcher_profiles.json', 'w') as f:
+    if os.path.exists("global/libraries"):
+        shutil.copytree(
+            "global/libraries", user_mcdir + "/libraries", dirs_exist_ok=True
+        )
+
+    with open(user_mcdir + "/launcher_profiles.json", "w") as f:
         json.dump(launcher_profiles, f, indent=2)
     # print(json.dumps(launcher_profiles, indent=2))
 
+
 if __name__ == "__main__":
     main()
-
-        

--- a/mod_download.py
+++ b/mod_download.py
@@ -14,7 +14,7 @@ from tqdm.asyncio import tqdm_asyncio
 api_url = "https://api.curseforge.com/v1"
 # NOTE: Modified and/or forked versions of this project must not use this API key.
 # Instead, please apply for a new API key from CurseForge's website.
-api_key = "$2a$10$t2BUHi3wKkiMw1YEqItui.XaHDvw4yMLK2peaKGkI9ufv3IsYRlkW"
+api_key = "NO_API_KEY"
 
 # temporary rate limit before CF implements a real one
 api_ratelimit = 5  # JSON requests per second

--- a/mod_download.py
+++ b/mod_download.py
@@ -7,21 +7,25 @@ import asyncio
 import time
 from util import download
 from concurrent.futures import ThreadPoolExecutor
+import tqdm
+from tqdm import tqdm  # class tqdm.tqdm, for .write()
+from tqdm.asyncio import tqdm_asyncio
 
-api_url = 'https://api.curseforge.com/v1'
+api_url = "https://api.curseforge.com/v1"
 # NOTE: Modified and/or forked versions of this project must not use this API key.
 # Instead, please apply for a new API key from CurseForge's website.
-api_key = '$2a$10$t2BUHi3wKkiMw1YEqItui.XaHDvw4yMLK2peaKGkI9ufv3IsYRlkW'
+api_key = "$2a$10$t2BUHi3wKkiMw1YEqItui.XaHDvw4yMLK2peaKGkI9ufv3IsYRlkW"
 
 # temporary rate limit before CF implements a real one
-api_ratelimit = 5 # JSON requests per second
-req_history = [0, 0] # time, request count so far
+api_ratelimit = 5  # JSON requests per second
+req_history = [0, 0]  # time, request count so far
+
 
 def get_json(session, url):
     r = session.get(url)
     if r.status_code != 200:
-        print("Error %d trying to access %s" % (r.status_code, url))
-        print(r.text)
+        tqdm.write("Error %d trying to access %s" % (r.status_code, url))
+        tqdm.write(r.text)
         return None
 
     req_history[1] += 1
@@ -35,50 +39,55 @@ def get_json(session, url):
 
     return json.loads(r.text)
 
+
 def fetch_mod(session, f, out_dir):
-    pid = f['projectID']
-    fid = f['fileID']
-    project_info = get_json(session, api_url + ('/mods/%d' % pid))
+    pid = f["projectID"]
+    fid = f["fileID"]
+    project_info = get_json(session, api_url + ("/mods/%d" % pid))
     if project_info is None:
-        print("fetch failed")
-        return (f, 'error')
-    project_info = project_info['data']
+        tqdm.write("fetch failed")
+        return (f, "error")
+    project_info = project_info["data"]
 
     # print(project_info)
-    print(project_info['links']['websiteUrl'])
-    file_type = project_info['links']['websiteUrl'].split('/')[4] # mc-mods or texture-packs
-    info = get_json(session, api_url + ('/mods/%d/files/%d' % (pid, fid)))
+    tqdm.write(project_info["links"]["websiteUrl"])
+    file_type = project_info["links"]["websiteUrl"].split("/")[
+        4
+    ]  # mc-mods or texture-packs
+    info = get_json(session, api_url + ("/mods/%d/files/%d" % (pid, fid)))
     if info is None:
-        print("fetch failed")
-        return (f, 'error')
-    info = info['data']
+        tqdm.write("fetch failed")
+        return (f, "error")
+    info = info["data"]
 
-    fn = info['fileName']
-    dl = info['downloadUrl']
-    out_file = out_dir + '/' + fn
+    fn = info["fileName"]
+    dl = info["downloadUrl"]
+    out_file = out_dir + "/" + fn
 
-    if not project_info['allowModDistribution']:
-        print("distribution disabled for this mod")
-        return (f, 'dist-error', project_info, out_file, file_type)
+    if not project_info["allowModDistribution"]:
+        tqdm.write("distribution disabled for this mod")
+        return (f, "dist-error", project_info, out_file, file_type)
 
     if os.path.exists(out_file):
-        if os.path.getsize(out_file) == info['fileLength']:
-            print("%s OK" % fn)
+        if os.path.getsize(out_file) == info["fileLength"]:
+            tqdm.write("%s OK" % fn)
             return (out_file, file_type)
-    
+
     status = download(dl, out_file, session=session, progress=True)
     if status != 200:
-        print("download failed (error %d)" % status)
-        return (f, 'error')
+        tqdm.write("download failed (error %d)" % status)
+        return (f, "error")
     return (out_file, file_type)
 
+
 async def download_mods_async(manifest, out_dir):
-    with ThreadPoolExecutor(max_workers=1) as executor, \
-            requests.Session() as session:
-        session.headers['X-Api-Key'] = api_key
+    with ThreadPoolExecutor(max_workers=1) as executor, requests.Session() as session:
+        session.headers["X-Api-Key"] = api_key
         loop = asyncio.get_event_loop()
         tasks = []
-        for f in manifest['files']:
+
+        # spawn tasks
+        for f in manifest["files"]:
             task = loop.run_in_executor(executor, fetch_mod, *(session, f, out_dir))
             tasks.append(task)
 
@@ -87,13 +96,21 @@ async def download_mods_async(manifest, out_dir):
         while len(tasks) > 0:
             retry_tasks = []
 
-            for resp in await asyncio.gather(*tasks):
-                if resp[1] == 'error':
-                    print("failed to fetch %s, retrying later" % resp[0])
+            for resp in await tqdm_asyncio.gather(
+                *tasks, unit="mod", desc="Downloading mods"
+            ):
+                if resp[1] == "error":
+                    tqdm.write("failed to fetch %s, retrying later" % resp[0])
                     retry_tasks.append(resp[0])
-                elif resp[1] == 'dist-error':
-                    manual_dl_url = resp[2]['links']['websiteUrl'] + '/download/' + str(resp[0]['fileID'])
-                    manual_dl_url = manual_dl_url.replace('www.curseforge.com', 'legacy.curseforge.com')
+                elif resp[1] == "dist-error":
+                    manual_dl_url = (
+                        resp[2]["links"]["websiteUrl"]
+                        + "/download/"
+                        + str(resp[0]["fileID"])
+                    )
+                    manual_dl_url = manual_dl_url.replace(
+                        "www.curseforge.com", "legacy.curseforge.com"
+                    )
                     manual_downloads.append((manual_dl_url, resp))
                     # add to jars list so that the file gets linked
                     jars.append(resp[3:])
@@ -102,16 +119,18 @@ async def download_mods_async(manifest, out_dir):
 
             tasks = []
             if len(retry_tasks) > 0:
-                print("retrying...")
+                tqdm.write(f"Retrying {len(retry_tasks)} mods in 2 seconds...")
                 time.sleep(2)
             for f in retry_tasks:
-                tasks.append(loop.run_in_executor(executor, fetch_mod, *(session, f, out_dir)))
+                # Retry failed downloads by spawning new tasks
+                tasks.append(
+                    loop.run_in_executor(executor, fetch_mod, *(session, f, out_dir))
+                )
         return jars, manual_downloads
 
 
 def main(manifest_json, mods_dir):
-    mod_jars = []
-    with open(manifest_json, 'r') as f:
+    with open(manifest_json, "r") as f:
         manifest = json.load(f)
 
     print("Downloading mods")
@@ -120,6 +139,7 @@ def main(manifest_json, mods_dir):
     future = asyncio.ensure_future(download_mods_async(manifest, mods_dir))
     loop.run_until_complete(future)
     return future.result()
+
 
 if __name__ == "__main__":
     print(main(sys.argv[1], sys.argv[2]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2023.5.7
+charset-normalizer==3.1.0
+idna==3.4
+requests==2.31.0
+tqdm==4.65.0
+urllib3==2.0.2

--- a/util.py
+++ b/util.py
@@ -3,39 +3,54 @@ import requests
 import shutil
 import json
 import os
+from tqdm import tqdm
 
-def status_bar(text, progress, bar_width=0.5, show_percent=True, borders='[]', progress_ch='#', space_ch=' '):
-    ansi_el = '\x1b[K\r' # escape code to clear the rest of the line plus carriage return
+
+def status_bar(
+    text,
+    progress,
+    bar_width=0.5,
+    show_percent=True,
+    borders="[]",
+    progress_ch="#",
+    space_ch=" ",
+):
+    ansi_el = (
+        "\x1b[K\r"  # escape code to clear the rest of the line plus carriage return
+    )
     term_width = shutil.get_terminal_size().columns
     if term_width < 10:
         print(end=ansi_el)
         return
     bar_width_c = max(int(term_width * bar_width), 4)
-    text_width = min(term_width - bar_width_c - 6, len(text)) # subract 4 characters for percentage and 2 spaces
-    text_part = '' if (text_width == 0) else text[-text_width:]
-    
+    text_width = min(
+        term_width - bar_width_c - 6, len(text)
+    )  # subract 4 characters for percentage and 2 spaces
+    text_part = "" if (text_width == 0) else text[-text_width:]
+
     progress_c = int(progress * (bar_width_c - 2))
     remaining_c = bar_width_c - 2 - progress_c
     padding_c = max(0, term_width - bar_width_c - text_width - 6)
 
     bar = borders[0] + progress_ch * progress_c + space_ch * remaining_c + borders[1]
-    pad = ' ' * padding_c
+    pad = " " * padding_c
     print("%s %s%3.0f%% %s" % (text_part, pad, (progress * 100), bar), end=ansi_el)
-    
+
+
 def download(url, dest, progress=False, session=None):
-    print("Downloading %s" % url)
+    tqdm.write("Downloading %s" % url)
 
     try:
         if session is not None:
             r = session.get(url, stream=True)
         else:
             r = requests.get(url, stream=True)
-        size = int(r.headers['Content-Length'])
-        
+        size = int(r.headers["Content-Length"])
+
         if r.status_code != 200:
             return r.status_code
 
-        with open(dest, 'wb') as f:
+        with open(dest, "wb") as f:
             if progress:
                 n = 0
                 for chunk in r.iter_content(1048576):
@@ -51,41 +66,45 @@ def download(url, dest, progress=False, session=None):
 
     if progress:
         print()
-    
+
     return r.status_code
 
+
 def rename_profile(launcher_profiles, orig_name, new_name):
-    orig_profile = launcher_profiles['profiles'][orig_name].copy()
-    del launcher_profiles['profiles'][orig_name]
-    launcher_profiles['profiles'][new_name] = orig_profile
-    launcher_profiles['profiles'][new_name]['name'] = new_name
+    orig_profile = launcher_profiles["profiles"][orig_name].copy()
+    del launcher_profiles["profiles"][orig_name]
+    launcher_profiles["profiles"][new_name] = orig_profile
+    launcher_profiles["profiles"][new_name]["name"] = new_name
+
 
 def __user_preferences_file():
     # create the user preferences file if it doesn't exist
-    if not os.path.isfile('user-preferences.json'):
-        with open('user-preferences.json', 'w') as f:
+    if not os.path.isfile("user-preferences.json"):
+        with open("user-preferences.json", "w") as f:
             json.dump({}, f)
+
 
 def get_user_preference(key):
     __user_preferences_file()
 
     # load the user preferences file
-    with open('user-preferences.json', 'r') as f:
+    with open("user-preferences.json", "r") as f:
         prefs = json.load(f)
-    
+
     # return the value if it exists, otherwise return None
     if key not in prefs:
         return None
     return prefs[key]
 
+
 def set_user_preference(key, value):
     __user_preferences_file()
 
     # load the user preferences file
-    with open('user-preferences.json', 'r') as f:
+    with open("user-preferences.json", "r") as f:
         prefs = json.load(f)
 
     # set the value and save the file
     prefs[key] = value
-    with open('user-preferences.json', 'w') as f:
+    with open("user-preferences.json", "w") as f:
         json.dump(prefs, f, indent=4)


### PR DESCRIPTION
# ✨ Progress Bars! ✨ 

As requested by cdbbnnyCode/modpack-installer#17, a number of progress bars have been added to the script thanks to the library [`tqdm`](https://github.com/tqdm/tqdm), the progress bars show current progres during lengthy operations such as mod downloading and linkage.

All print statements that are contained inside of a tqdm context (basically a for loop that is being tracked by a progress bar) have been rewritten to use `tqdm.tqdm.write`, as to not break the progress bars, `tqdm.tqdm.write` prints stuff *above* the progressbar, so the bar always stays at the bottom, for example:

![downloading_mods](https://github.com/cdbbnnyCode/modpack-installer/assets/77234595/28422f81-9b05-42ab-aa39-d5ee1e203ed5)



## 📝 Formatting 📝 

All the scripts have been formatted by the [`black`](https://github.com/psf/black) formatter for improved readability (admittedly this is kind of intrusive and I should have separated this on a second commit, shame on me).

## 📌 Requirements 📌 

Generated a `requirements.txt` listing the minimal requirements in order to run the scripts (by creating a venv, installing `requests` and `tqdm` and then running `pip freeze > requirements.txt`.

Now users can install all dependencies in one go as follows:
```
git clone https://github.com/cdbbnnyCode/modpack-installer.git
cd modpack-installer
pip install -r ./requirements.txt
```